### PR TITLE
Fix opencv framework search path

### DIFF
--- a/ios/RNCustomCrop.xcodeproj/project.pbxproj
+++ b/ios/RNCustomCrop.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		D2BCBB0F1F47841A001B66CF /* CustomCropManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = D2BCBB0E1F47841A001B66CF /* CustomCropManager.mm */; };
-		D2ED14E51F49D18A00BACABE /* opencv2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2ED14E41F49D18A00BACABE /* opencv2.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,7 +26,6 @@
 		134814201AA4EA6300B7C361 /* libRNCustomCrop.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNCustomCrop.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2BCBB0D1F47841A001B66CF /* CustomCropManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomCropManager.h; sourceTree = "<group>"; };
 		D2BCBB0E1F47841A001B66CF /* CustomCropManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CustomCropManager.mm; sourceTree = "<group>"; };
-		D2ED14E41F49D18A00BACABE /* opencv2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = opencv2.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -35,7 +33,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D2ED14E51F49D18A00BACABE /* opencv2.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -53,7 +50,6 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				D2ED14E41F49D18A00BACABE /* opencv2.framework */,
 				D2BCBB0D1F47841A001B66CF /* CustomCropManager.h */,
 				D2BCBB0E1F47841A001B66CF /* CustomCropManager.mm */,
 				134814211AA4EA7D00B7C361 /* Products */,
@@ -202,7 +198,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)",
+					"$(SRCROOT)",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -222,7 +218,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)",
+					"$(SRCROOT)",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/RNCustomCrop.xcodeproj/project.pbxproj
+++ b/ios/RNCustomCrop.xcodeproj/project.pbxproj
@@ -197,8 +197,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../ios/",
 					"$(inherited)",
-					"$(SRCROOT)",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -217,8 +217,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../ios/",
 					"$(inherited)",
-					"$(SRCROOT)",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "react-native-perspective-image-cropper",
+  "version": "0.1.2",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/Michaelvilleneuve/react-native-perspective-image-cropper"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Michaelvilleneuve/react-native-perspective-image-cropper"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
#4

The way it was done was not working the way it's write in the documentation. The opencv framework was linked to the module instead of root project.

To make it work we should have to copy the framework into /node_modules/react-native-perspective-image-cropper/ios, that means that each time we reinstall dependencies into the project, we should have done the copy step.

I have changed the path to the parent project so it's not annoying anymore.