### PR TITLE
Fix warning 'Animated.event now requires a second argument for options'

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,9 @@ class CustomCrop extends Component {
                     dx: corner.x,
                     dy: corner.y,
                 },
-            ]),
+              ],
+              {useNativeDriver: false}
+            ),
             onPanResponderRelease: () => {
                 corner.flattenOffset();
                 this.updateOverlayString();


### PR DESCRIPTION
When dragging at a corner during cropping following warning appeared:

_Animated.event now requires a second argument for options_

As nativeDrivers are not supported on PanResponders, we need to set it to _false_