### PR TITLE
fix cropped region on ios

### DIFF
--- a/android/src/main/java/fr/michaelvilleneuve/customcrop/RNCustomCropModule.java
+++ b/android/src/main/java/fr/michaelvilleneuve/customcrop/RNCustomCropModule.java
@@ -65,20 +65,18 @@ public class RNCustomCropModule extends ReactContextBaseJavaModule {
 
     Mat src = Imgcodecs.imread(imageUri.replace("file://", ""), Imgproc.COLOR_BGR2RGB);
     Imgproc.cvtColor(src, src, Imgproc.COLOR_BGR2RGB);
-
-    boolean ratioAlreadyApplied = tr.x * (src.size().width / 500) < src.size().width;
-    double ratio = ratioAlreadyApplied ? src.size().width / 500 : 1;
+    Imgproc.resize(src, src, new Size(points.getDouble("width"), points.getDouble("height")));
 
     double widthA = Math.sqrt(Math.pow(br.x - bl.x, 2) + Math.pow(br.y - bl.y, 2));
     double widthB = Math.sqrt(Math.pow(tr.x - tl.x, 2) + Math.pow(tr.y - tl.y, 2));
 
-    double dw = Math.max(widthA, widthB) * ratio;
+    double dw = Math.max(widthA, widthB);
     int maxWidth = Double.valueOf(dw).intValue();
 
     double heightA = Math.sqrt(Math.pow(tr.x - br.x, 2) + Math.pow(tr.y - br.y, 2));
     double heightB = Math.sqrt(Math.pow(tl.x - bl.x, 2) + Math.pow(tl.y - bl.y, 2));
 
-    double dh = Math.max(heightA, heightB) * ratio;
+    double dh = Math.max(heightA, heightB);
     int maxHeight = Double.valueOf(dh).intValue();
 
     Mat doc = new Mat(maxHeight, maxWidth, CvType.CV_8UC4);
@@ -86,8 +84,7 @@ public class RNCustomCropModule extends ReactContextBaseJavaModule {
     Mat src_mat = new Mat(4, 1, CvType.CV_32FC2);
     Mat dst_mat = new Mat(4, 1, CvType.CV_32FC2);
 
-    src_mat.put(0, 0, tl.x * ratio, tl.y * ratio, tr.x * ratio, tr.y * ratio, br.x * ratio, br.y * ratio, bl.x * ratio,
-        bl.y * ratio);
+    src_mat.put(0, 0, tl.x, tl.y, tr.x, tr.y, br.x, br.y, bl.x, bl.y);
     dst_mat.put(0, 0, 0.0, 0.0, dw, 0.0, dw, dh, 0.0, dh);
 
     Mat m = Imgproc.getPerspectiveTransform(src_mat, dst_mat);

--- a/android/src/main/java/fr/michaelvilleneuve/customcrop/RNCustomCropModule.java
+++ b/android/src/main/java/fr/michaelvilleneuve/customcrop/RNCustomCropModule.java
@@ -65,18 +65,20 @@ public class RNCustomCropModule extends ReactContextBaseJavaModule {
 
     Mat src = Imgcodecs.imread(imageUri.replace("file://", ""), Imgproc.COLOR_BGR2RGB);
     Imgproc.cvtColor(src, src, Imgproc.COLOR_BGR2RGB);
-    Imgproc.resize(src, src, new Size(points.getDouble("width"), points.getDouble("height")));
+
+    boolean ratioAlreadyApplied = tr.x * (src.size().width / 500) < src.size().width;
+    double ratio = ratioAlreadyApplied ? src.size().width / 500 : 1;
 
     double widthA = Math.sqrt(Math.pow(br.x - bl.x, 2) + Math.pow(br.y - bl.y, 2));
     double widthB = Math.sqrt(Math.pow(tr.x - tl.x, 2) + Math.pow(tr.y - tl.y, 2));
 
-    double dw = Math.max(widthA, widthB);
+    double dw = Math.max(widthA, widthB) * ratio;
     int maxWidth = Double.valueOf(dw).intValue();
 
     double heightA = Math.sqrt(Math.pow(tr.x - br.x, 2) + Math.pow(tr.y - br.y, 2));
     double heightB = Math.sqrt(Math.pow(tl.x - bl.x, 2) + Math.pow(tl.y - bl.y, 2));
 
-    double dh = Math.max(heightA, heightB);
+    double dh = Math.max(heightA, heightB) * ratio;
     int maxHeight = Double.valueOf(dh).intValue();
 
     Mat doc = new Mat(maxHeight, maxWidth, CvType.CV_8UC4);
@@ -84,7 +86,8 @@ public class RNCustomCropModule extends ReactContextBaseJavaModule {
     Mat src_mat = new Mat(4, 1, CvType.CV_32FC2);
     Mat dst_mat = new Mat(4, 1, CvType.CV_32FC2);
 
-    src_mat.put(0, 0, tl.x, tl.y, tr.x, tr.y, br.x, br.y, bl.x, bl.y);
+    src_mat.put(0, 0, tl.x * ratio, tl.y * ratio, tr.x * ratio, tr.y * ratio, br.x * ratio, br.y * ratio, bl.x * ratio,
+        bl.y * ratio);
     dst_mat.put(0, 0, 0.0, 0.0, dw, 0.0, dw, dh, 0.0, dh);
 
     Mat m = Imgproc.getPerspectiveTransform(src_mat, dst_mat);

--- a/ios/CustomCropManager.mm
+++ b/ios/CustomCropManager.mm
@@ -10,6 +10,7 @@ RCT_EXPORT_METHOD(crop:(NSDictionary *)points imageUri:(NSString *)imageUri call
     NSString *parsedImageUri = [imageUri stringByReplacingOccurrencesOfString:@"file://" withString:@""];
     NSURL *fileURL = [NSURL fileURLWithPath:parsedImageUri];
     CIImage *ciImage = [CIImage imageWithContentsOfURL:fileURL];
+    ciImage = [ciImage imageByApplyingOrientation:kCGImagePropertyOrientationRightMirrored];
     
     CGPoint newLeft = CGPointMake([points[@"topLeft"][@"x"] floatValue], [points[@"topLeft"][@"y"] floatValue]);
     CGPoint newRight = CGPointMake([points[@"topRight"][@"x"] floatValue], [points[@"topRight"][@"y"] floatValue]);
@@ -41,7 +42,7 @@ RCT_EXPORT_METHOD(crop:(NSDictionary *)points imageUri:(NSString *)imageUri call
 }
 
 - (CGPoint)cartesianForPoint:(CGPoint)point height:(float)height {
-    return CGPointMake(point.x, height - point.y);
+    return CGPointMake(point.x, point.y);
 }
 
 @end

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageImportPath:
+          "import fr.michaelvilleneuve.customcrop.RNCustomCropPackage;",
+        packageInstance: "new RNCustomCropPackage()",
+      },
+    },
+  },
+};


### PR DESCRIPTION
The cropped area on iOS was not aligning with the rectangle & coordinates drawn on the screen. After merging this code, the image provided from the cropper matches what you'd expect. 